### PR TITLE
DM-45600: Update docker-in-docker image.

### DIFF
--- a/agents-yaml/idf-agent-ldfc-dev.yaml
+++ b/agents-yaml/idf-agent-ldfc-dev.yaml
@@ -23,7 +23,7 @@ spec:
         env:
         - name: DOCKER_HOST
           value: tcp://localhost:2375
-        image: lsstsqre/dind:18.09.5
+        image: docker:27.1.1-dind
         imagePullPolicy: Always
         livenessProbe:
           exec:


### PR DESCRIPTION
18.09.5 is too old to run almalinux:9.
27.1.1 appears to work correctly.
There should be no need for the custom lsstsqre image now.
Update this in dev first.