### PR TITLE
Stop tracking gke version

### DIFF
--- a/terraform/prod/gke.tf
+++ b/terraform/prod/gke.tf
@@ -20,7 +20,6 @@ resource "google_container_cluster" "jenkins_test" {
   network                                  = "projects/prompt-proto/global/networks/prompt-proto-net"
   networking_mode                          = "VPC_NATIVE"
   node_locations                           = []
-  node_version                             = "1.30.9-gke.1201000"
   project                                  = "prompt-proto"
   #resource_labels                          = {}
   subnetwork = "projects/prompt-proto/regions/us-central1/subnetworks/prompt-proto-sub-1"
@@ -152,7 +151,6 @@ resource "google_container_cluster" "jenkins_test" {
     node_locations = [
       "us-central1-c",
     ]
-    version = "1.30.9-gke.1201000"
 
     management {
       auto_repair  = true
@@ -224,7 +222,6 @@ resource "google_container_cluster" "jenkins_test" {
     node_locations = [
       "us-central1-a",
     ]
-    version = "1.30.9-gke.1201000"
 
     management {
       auto_repair  = true

--- a/terraform/prod/nodepool.tf
+++ b/terraform/prod/nodepool.tf
@@ -10,7 +10,6 @@ resource "google_container_node_pool" "jenkins_workers_big" {
     "us-central1-c",
   ]
   project = "prompt-proto"
-  version = "1.30.9-gke.1201000"
 
   management {
     auto_repair  = true
@@ -79,7 +78,6 @@ resource "google_container_node_pool" "jenkins_workers_multiarch_c4a" {
     "us-central1-a",
   ]
   project = "prompt-proto"
-  version = "1.30.9-gke.1201000"
 
   management {
     auto_repair  = true


### PR DESCRIPTION
Tracking gke version is not really needed and has caused more maintenance than needed. 