### PR TITLE
Update grafana applied address, and atlantis allow list

### DIFF
--- a/helm-charts/atlantis/README.md
+++ b/helm-charts/atlantis/README.md
@@ -32,6 +32,7 @@ Once the PR has been reviewed and approved, you can apply these changes to our g
 ```text
 atlantis apply
 ```
+Ensure you do this BEFORE you merge your PR, otherwise it will not be able to apply.
 
 ### 4. Unlock
 Locks and plans after `atlantis apply` will be removed. If you need to close the PR without applying, or want to delete plans and locks, do `atlantis unlock`. This is not required if you did `atlantis apply`.

--- a/helm-charts/atlantis/values-atlantis.yaml
+++ b/helm-charts/atlantis/values-atlantis.yaml
@@ -15,7 +15,7 @@ atlantisUrl: "https://ci-atlantis.lsst.cloud/"
 # Example:  http://10.0.0.0
 
 # -- Replace this with your own repo allowlist.
-orgAllowlist: "github.com/lsst-dm/jenkins-workers-deploy"
+orgAllowlist: "github.com/lsst-dm/jenkins-dm-workers"
 
 # -- Deprecated in favor of orgAllowlist.
 orgWhitelist: "<deprecated>"

--- a/terraform/prod/nat.tf
+++ b/terraform/prod/nat.tf
@@ -113,6 +113,7 @@ resource "google_compute_global_address" "atlantis" {
 
 resource "google_compute_global_address" "grafana" {
   name               = "grafana"
+  address            = "35.190.2.90"
   address_type       = "EXTERNAL"
   description        = "Static external IP for deploying grafana."
   labels             = {}


### PR DESCRIPTION
Updating the IP address for grafana and repo allow list for atlantis since I changed the name from `jenkins-workers-deploy` to `jenkins-dm-workers`. 