### PR TITLE
Bump memory limits to 4Gi in values-postgresql.yaml

### DIFF
--- a/helm-charts/sonarqube/values-postgresql.yaml
+++ b/helm-charts/sonarqube/values-postgresql.yaml
@@ -16,7 +16,7 @@ primary:
       memory: 256Mi
       cpu: 100m
     limits:
-      memory: 512Mi
+      memory: 1024Mi
       cpu: 500m
   persistence:
     storageClass: standard-rwo

--- a/helm-charts/sonarqube/values-postgresql.yaml
+++ b/helm-charts/sonarqube/values-postgresql.yaml
@@ -16,7 +16,7 @@ primary:
       memory: 256Mi
       cpu: 100m
     limits:
-      memory: 1024Mi
+      memory: 4Gi
       cpu: 500m
   persistence:
     storageClass: standard-rwo


### PR DESCRIPTION
Bump memory from 512Mi to 1024Mi to avoid OOM pod restarts.