### PR TITLE
Tickets/DM-55407: Add fallback nodes for workers

### DIFF
--- a/agents-yaml/compute-classes/README.md
+++ b/agents-yaml/compute-classes/README.md
@@ -1,0 +1,56 @@
+# ComputeClasses Guide
+
+These two [custom ComputeClasses](https://cloud.google.com/kubernetes-engine/docs/concepts/about-custom-compute-classes)
+are what give worker pods a fallback machine family when the primary one is out of
+capacity.
+
+| ComputeClass | Priority 1 | Priority 2 |
+|---|---|---|
+| `jenkins-workers-x86` | `jenkins-workers-c4d` | `jenkins-workers-c4-fallback` |
+| `jenkins-workers-arm` | `jenkins-workers-multiarch-c4a` | `jenkins-workers-n4a-fallback` |
+
+ComputeClasses are cluster-scoped, so one copy serves both the `jenkins-prod` and
+`jenkins-dev` namespaces. Requires GKE 1.30.3-gke.1451000 or later.
+
+```bash
+kubectl apply -f jenkins-workers-x86.yaml -f jenkins-workers-arm.yaml
+kubectl get computeclass
+```
+
+## Why this rather than a second Jenkins pod template
+
+The Jenkins Kubernetes plugin cannot fall back on its own. `KubernetesCloud.provision()`
+walks the templates matching a label in declaration order and returns on the first one
+that plans a node, so a second template with the same label is never reached. And
+`KubernetesLauncher` only waits out `slaveConnectTimeout` before throwing — it never
+inspects pod conditions, so a stockout is indistinguishable from a slow boot and the
+pipeline gets no signal it could act on. GKE is the only layer that knows a pool is
+out of capacity, so the decision has to live there.
+
+## Pods must select the class, not the pool
+
+Worker pods carry `nodeSelector: cloud.google.com/compute-class: <class name>` instead
+of `cloud.google.com/gke-nodepool: <pool>`. Pinning a pool defeats the fallback.
+
+The four worker pools are also **tainted** `cloud.google.com/compute-class=<class>:NoSchedule`,
+which is what keeps unrelated pods off them now that no pod pins a pool. GKE
+auto-injects the matching toleration into any pod that selects the class, so pods
+normally need only the nodeSelector — the agent templates spell the toleration out
+anyway so the spec stands alone.
+
+**A pod that is still pinned to a worker pool by name needs the toleration added by
+hand,** because the auto-injection only fires for pods that select the class. This is
+why `snowflake` carries an explicit `jenkins-workers-arm` toleration: it stays pinned
+to C4A on purpose (it is a long-lived stateful agent, not something we want migrating
+between machine families) and would otherwise go unschedulable the moment the pool was
+tainted.
+
+Both the label and the taint have to be set on the pools explicitly, in
+`terraform/prod/nodepool.tf` — GKE only applies them automatically to pools it
+creates itself, not to manually created ones.
+
+## Changing the fallback family
+
+This is entirely a change in this repo: edit the pool in `nodepool.tf` and the
+`priorities` list here. Nothing in `jenkins-dm-jobs` refers to a pool name, only to
+the class name, so no Jenkins-side change or `helm upgrade` is needed.

--- a/agents-yaml/compute-classes/jenkins-workers-arm.yaml
+++ b/agents-yaml/compute-classes/jenkins-workers-arm.yaml
@@ -1,0 +1,23 @@
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: jenkins-workers-arm
+spec:
+  # Each priority rule is tried in order, so a pod only lands on N4A once C4A has
+  # no capacity. Pools within one rule would be unordered, hence one pool per rule.
+  #
+  # Both families are Axion (arm64) and both accept hyperdisk-balanced, which is
+  # what lets arm agent pods declare the same /j volume as x86 ones. Any future
+  # fallback family must also accept hyperdisk-balanced: a pod's volume spec is
+  # fixed before it is scheduled, so a family without Hyperdisk would leave the pod
+  # deadlocked on volume attach -- worse than the stockout this exists to escape.
+  # T2A was rejected as the fallback for exactly this reason (pd-balanced only).
+  priorities:
+  - nodepools: [jenkins-workers-multiarch-c4a]
+  - nodepools: [jenkins-workers-n4a-fallback]
+  # Leave the pod Pending rather than scaling up a node with the cluster's default
+  # machine configuration, which would be x86 and could not run an arm64 image.
+  whenUnsatisfiable: DoNotScaleUp
+  # activeMigration is deliberately unset. optimizeRulePriority would drain pods
+  # off the fallback pool once C4A capacity returned, which for this cluster means
+  # killing multi-hour stack builds mid-flight.

--- a/agents-yaml/compute-classes/jenkins-workers-x86.yaml
+++ b/agents-yaml/compute-classes/jenkins-workers-x86.yaml
@@ -1,0 +1,18 @@
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: jenkins-workers-x86
+spec:
+  # Each priority rule is tried in order, so a pod only lands on C4 once C4D has
+  # no capacity. Pools within one rule would be unordered, hence one pool per rule.
+  priorities:
+  - nodepools: [jenkins-workers-c4d]
+  - nodepools: [jenkins-workers-c4-fallback]
+  # Leave the pod Pending rather than scaling up a node with the cluster's default
+  # machine configuration. A default node would be the wrong size and, more
+  # importantly, would not accept the hyperdisk-balanced /j volume the agent pods
+  # declare, so the pod would fail on volume attach instead of simply waiting.
+  whenUnsatisfiable: DoNotScaleUp
+  # activeMigration is deliberately unset. optimizeRulePriority would drain pods
+  # off the fallback pool once C4D capacity returned, which for this cluster means
+  # killing multi-hour stack builds mid-flight.

--- a/agents-yaml/dev/auto-agents/jenkins-agent-arch-c4a-dev.yaml
+++ b/agents-yaml/dev/auto-agents/jenkins-agent-arch-c4a-dev.yaml
@@ -152,7 +152,7 @@ spec:
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: jenkins-workers-multiarch-c4a
+    cloud.google.com/compute-class: jenkins-workers-arm
     kubernetes.io/arch: arm64
   preemptionPolicy: PreemptLowerPriority
   priority: 0
@@ -168,6 +168,10 @@ spec:
   shareProcessNamespace: false
   terminationGracePeriodSeconds: 30
   tolerations:
+  - effect: NoSchedule
+    key: cloud.google.com/compute-class
+    operator: Equal
+    value: jenkins-workers-arm
   - effect: NoExecute
     key: node.kubernetes.io/not-ready
     operator: Exists

--- a/agents-yaml/dev/auto-agents/jenkins-agent-x86-c4d-dev.yaml
+++ b/agents-yaml/dev/auto-agents/jenkins-agent-x86-c4d-dev.yaml
@@ -150,7 +150,7 @@ spec:
       readOnly: true
   dnsPolicy: ClusterFirst
   nodeSelector:
-    cloud.google.com/gke-nodepool: jenkins-workers-c4d
+    cloud.google.com/compute-class: jenkins-workers-x86
   enableServiceLinks: true
   preemptionPolicy: PreemptLowerPriority
   priority: 0
@@ -166,6 +166,10 @@ spec:
   shareProcessNamespace: false
   terminationGracePeriodSeconds: 1200
   tolerations:
+  - effect: NoSchedule
+    key: cloud.google.com/compute-class
+    operator: Equal
+    value: jenkins-workers-x86
   - effect: NoExecute
     key: node.kubernetes.io/not-ready
     operator: Exists

--- a/agents-yaml/dev/static-agents/snowflake-dev.yaml
+++ b/agents-yaml/dev/static-agents/snowflake-dev.yaml
@@ -174,6 +174,11 @@ spec:
           name: ws-snowflake-dev
         workingDir: /j
       dnsPolicy: ClusterFirst
+      # Deliberately pinned to the C4A pool by name rather than selecting the
+      # jenkins-workers-arm ComputeClass: this is a long-lived stateful agent and we
+      # do not want it migrating between machine families. The cost of staying pinned
+      # is the explicit compute-class toleration below -- GKE only auto-injects that
+      # toleration for pods that select the class.
       nodeSelector:
         cloud.google.com/gke-nodepool: jenkins-workers-multiarch-c4a
         kubernetes.io/arch: arm64
@@ -187,6 +192,10 @@ spec:
       shareProcessNamespace: false
       terminationGracePeriodSeconds: 30
       tolerations:
+      - effect: NoSchedule
+        key: cloud.google.com/compute-class
+        operator: Equal
+        value: jenkins-workers-arm
       - effect: NoExecute
         key: workload
         operator: Equal

--- a/agents-yaml/prod/auto-agents/jenkins-agent-arch-c4a.yaml
+++ b/agents-yaml/prod/auto-agents/jenkins-agent-arch-c4a.yaml
@@ -158,7 +158,7 @@ spec:
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   nodeSelector:
-    workload: workers
+    cloud.google.com/compute-class: jenkins-workers-arm
     kubernetes.io/arch: arm64
   preemptionPolicy: PreemptLowerPriority
   priority: 0
@@ -174,6 +174,10 @@ spec:
   shareProcessNamespace: false
   terminationGracePeriodSeconds: 30
   tolerations:
+  - effect: NoSchedule
+    key: cloud.google.com/compute-class
+    operator: Equal
+    value: jenkins-workers-arm
   - effect: NoExecute
     key: node.kubernetes.io/not-ready
     operator: Exists

--- a/agents-yaml/prod/auto-agents/jenkins-agent-arch-c4a.yaml
+++ b/agents-yaml/prod/auto-agents/jenkins-agent-arch-c4a.yaml
@@ -158,7 +158,7 @@ spec:
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: jenkins-workers-multiarch-c4a
+    workload: workers
     kubernetes.io/arch: arm64
   preemptionPolicy: PreemptLowerPriority
   priority: 0

--- a/agents-yaml/prod/auto-agents/jenkins-agent-x86-c4d.yaml
+++ b/agents-yaml/prod/auto-agents/jenkins-agent-x86-c4d.yaml
@@ -156,7 +156,7 @@ spec:
       readOnly: true
   dnsPolicy: ClusterFirst
   nodeSelector:
-    worktype: workers
+    cloud.google.com/compute-class: jenkins-workers-x86
   enableServiceLinks: true
   preemptionPolicy: PreemptLowerPriority
   priority: 0
@@ -172,6 +172,10 @@ spec:
   shareProcessNamespace: false
   terminationGracePeriodSeconds: 30
   tolerations:
+  - effect: NoSchedule
+    key: cloud.google.com/compute-class
+    operator: Equal
+    value: jenkins-workers-x86
   - effect: NoExecute
     key: node.kubernetes.io/not-ready
     operator: Exists

--- a/agents-yaml/prod/auto-agents/jenkins-agent-x86-c4d.yaml
+++ b/agents-yaml/prod/auto-agents/jenkins-agent-x86-c4d.yaml
@@ -156,7 +156,7 @@ spec:
       readOnly: true
   dnsPolicy: ClusterFirst
   nodeSelector:
-    cloud.google.com/gke-nodepool: jenkins-workers-c4d
+    worktype: workers
   enableServiceLinks: true
   preemptionPolicy: PreemptLowerPriority
   priority: 0

--- a/agents-yaml/prod/static-agents/snowflake.yaml
+++ b/agents-yaml/prod/static-agents/snowflake.yaml
@@ -177,6 +177,11 @@ spec:
           name: ws-snowflake
         workingDir: /j
       dnsPolicy: ClusterFirst
+      # Deliberately pinned to the C4A pool by name rather than selecting the
+      # jenkins-workers-arm ComputeClass: this is a long-lived stateful agent and we
+      # do not want it migrating between machine families. The cost of staying pinned
+      # is the explicit compute-class toleration below -- GKE only auto-injects that
+      # toleration for pods that select the class.
       nodeSelector:
         cloud.google.com/gke-nodepool: jenkins-workers-multiarch-c4a
         kubernetes.io/arch: arm64
@@ -190,6 +195,10 @@ spec:
       shareProcessNamespace: false
       terminationGracePeriodSeconds: 30
       tolerations:
+      - effect: NoSchedule
+        key: cloud.google.com/compute-class
+        operator: Equal
+        value: jenkins-workers-arm
       - effect: NoExecute
         key: workload
         operator: Equal

--- a/terraform/prod/monitoring.tf
+++ b/terraform/prod/monitoring.tf
@@ -11,7 +11,7 @@ resource "google_monitoring_dashboard" "jenkins_agent_usage" {
             dataSets = [{
               timeSeriesQuery = {
                 timeSeriesFilter = {
-                  filter      = "resource.type=\"k8s_container\" metric.type=\"kubernetes.io/container/cpu/core_usage_time\" resource.label.\"namespace_name\"=\"jenkins\" metadata.user_labels.\"app\"=monitoring.regex.full_match(\"idf-agent-ldfc.*\")"
+                  filter = "resource.type=\"k8s_container\" metric.type=\"kubernetes.io/container/cpu/core_usage_time\" resource.label.\"namespace_name\"=\"jenkins\" metadata.user_labels.\"app\"=monitoring.regex.full_match(\"idf-agent-ldfc.*\")"
                   aggregation = {
                     alignmentPeriod  = "60s"
                     perSeriesAligner = "ALIGN_RATE"
@@ -27,7 +27,7 @@ resource "google_monitoring_dashboard" "jenkins_agent_usage" {
             dataSets = [{
               timeSeriesQuery = {
                 timeSeriesFilter = {
-                  filter      = "resource.type=\"k8s_container\" metric.type=\"kubernetes.io/container/memory/used_bytes\" resource.label.\"namespace_name\"=\"jenkins\" metadata.user_labels.\"app\"=monitoring.regex.full_match(\"idf-agent-ldfc.*\")"
+                  filter = "resource.type=\"k8s_container\" metric.type=\"kubernetes.io/container/memory/used_bytes\" resource.label.\"namespace_name\"=\"jenkins\" metadata.user_labels.\"app\"=monitoring.regex.full_match(\"idf-agent-ldfc.*\")"
                   aggregation = {
                     alignmentPeriod  = "60s"
                     perSeriesAligner = "ALIGN_MEAN"

--- a/terraform/prod/monitoring.tf
+++ b/terraform/prod/monitoring.tf
@@ -1,0 +1,43 @@
+resource "google_monitoring_dashboard" "jenkins_agent_usage" {
+  project = "prompt-proto"
+  dashboard_json = jsonencode({
+    displayName = "Jenkins Agent Resource Usage"
+    gridLayout = {
+      columns = 2
+      widgets = [
+        {
+          title = "Agent container CPU (cores used)"
+          xyChart = {
+            dataSets = [{
+              timeSeriesQuery = {
+                timeSeriesFilter = {
+                  filter      = "resource.type=\"k8s_container\" metric.type=\"kubernetes.io/container/cpu/core_usage_time\" resource.label.\"namespace_name\"=\"jenkins\" metadata.user_labels.\"app\"=monitoring.regex.full_match(\"idf-agent-ldfc.*\")"
+                  aggregation = {
+                    alignmentPeriod  = "60s"
+                    perSeriesAligner = "ALIGN_RATE"
+                  }
+                }
+              }
+            }]
+          }
+        },
+        {
+          title = "Agent container memory (bytes used)"
+          xyChart = {
+            dataSets = [{
+              timeSeriesQuery = {
+                timeSeriesFilter = {
+                  filter      = "resource.type=\"k8s_container\" metric.type=\"kubernetes.io/container/memory/used_bytes\" resource.label.\"namespace_name\"=\"jenkins\" metadata.user_labels.\"app\"=monitoring.regex.full_match(\"idf-agent-ldfc.*\")"
+                  aggregation = {
+                    alignmentPeriod  = "60s"
+                    perSeriesAligner = "ALIGN_MEAN"
+                  }
+                }
+              }
+            }]
+          }
+        }
+      ]
+    }
+  })
+}

--- a/terraform/prod/nat.tf
+++ b/terraform/prod/nat.tf
@@ -99,66 +99,66 @@ resource "google_compute_address" "address" {
 }
 
 resource "google_compute_global_address" "atlantis" {
-  name               = "atlantis"
-  address            = "34.111.195.59"
-  address_type       = "EXTERNAL"
-  description        = "Static external IP for deploying atlantis."
-  labels             = {}
-  network            = null
-  ip_version         = "IPV4"
-  prefix_length      = 0
-  project            = "prompt-proto"
-  purpose            = null
+  name          = "atlantis"
+  address       = "34.111.195.59"
+  address_type  = "EXTERNAL"
+  description   = "Static external IP for deploying atlantis."
+  labels        = {}
+  network       = null
+  ip_version    = "IPV4"
+  prefix_length = 0
+  project       = "prompt-proto"
+  purpose       = null
 }
 
 resource "google_compute_global_address" "grafana" {
-  name               = "grafana"
-  address            = "35.190.2.90"
-  address_type       = "EXTERNAL"
-  description        = "Static external IP for deploying grafana."
-  labels             = {}
-  network            = null
-  ip_version         = "IPV4"
-  prefix_length      = 0
-  project            = "prompt-proto"
-  purpose            = null
+  name          = "grafana"
+  address       = "35.190.2.90"
+  address_type  = "EXTERNAL"
+  description   = "Static external IP for deploying grafana."
+  labels        = {}
+  network       = null
+  ip_version    = "IPV4"
+  prefix_length = 0
+  project       = "prompt-proto"
+  purpose       = null
 }
 
 resource "google_compute_global_address" "vault-external" {
-  name               = "vault-external"    
-  address            = "34.110.184.84"
-  address_type       = "EXTERNAL"
-  ip_version         = "IPV4"
-  labels             = {}
-  network            = null
-  prefix_length      = 0
-  project            = "prompt-proto"
-  purpose            = null
+  name          = "vault-external"
+  address       = "34.110.184.84"
+  address_type  = "EXTERNAL"
+  ip_version    = "IPV4"
+  labels        = {}
+  network       = null
+  prefix_length = 0
+  project       = "prompt-proto"
+  purpose       = null
 }
 
 resource "google_compute_global_address" "jenkins" {
-  name               = "jenkins"
-  address            = "34.8.191.153"
-  address_type       = "EXTERNAL"
-  ip_version         = "IPV4"
-  labels             = {}
-  network            = null
-  prefix_length      = 0
-  project            = "prompt-proto"
-  purpose            = null
+  name          = "jenkins"
+  address       = "34.8.191.153"
+  address_type  = "EXTERNAL"
+  ip_version    = "IPV4"
+  labels        = {}
+  network       = null
+  prefix_length = 0
+  project       = "prompt-proto"
+  purpose       = null
 }
 
 resource "google_compute_global_address" "jenkins-dev" {
-  name               = "jenkins-dev"
-  address            = "34.49.198.194"
-  address_type       = "EXTERNAL"
-  description        = "External IP for dev jenkins."
-  ip_version         = "IPV4"
-  labels             = {}
-  network            = null
-  prefix_length      = 0
-  project            = "prompt-proto"
-  purpose            = null
+  name          = "jenkins-dev"
+  address       = "34.49.198.194"
+  address_type  = "EXTERNAL"
+  description   = "External IP for dev jenkins."
+  ip_version    = "IPV4"
+  labels        = {}
+  network       = null
+  prefix_length = 0
+  project       = "prompt-proto"
+  purpose       = null
 }
 
 resource "google_compute_router_nat_address" "nat_address" {

--- a/terraform/prod/nodepool.tf
+++ b/terraform/prod/nodepool.tf
@@ -106,11 +106,18 @@ resource "google_container_node_pool" "jenkins_workers_c4d" {
     enable_confidential_storage = false
     image_type                  = "COS_CONTAINERD"
     labels = {
-      "worktype" = "workers"
+      "worktype"                       = "workers"
+      "cloud.google.com/compute-class" = "jenkins-workers-x86"
     }
     local_ssd_count = 0
     logging_variant = "DEFAULT"
     machine_type    = "c4d-standard-32"
+
+    taint {
+      key    = "cloud.google.com/compute-class"
+      value  = "jenkins-workers-x86"
+      effect = "NO_SCHEDULE"
+    }
     metadata = {
       "disable-legacy-endpoints" = "true"
     }
@@ -153,9 +160,9 @@ resource "google_container_node_pool" "jenkins_workers_c4d" {
 }
 
 
-# x86 fallback pool. Shares the "worktype=workers" node label with
-# jenkins-workers-c4d so x86 agent pods can land here when C4D capacity is
-# unavailable (stockout). c4-standard-32 is also hyperdisk-only.
+# x86 fallback pool, priority 2 of the jenkins-workers-x86 ComputeClass: x86 agent
+# pods land here when C4D is out of capacity. c4-standard-32 is also hyperdisk-only,
+# so it takes the same /j volume spec as C4D.
 resource "google_container_node_pool" "jenkins_workers_c4_fallback" {
   cluster            = google_container_cluster.jenkins_test.name
   location           = google_container_cluster.jenkins_test.location
@@ -191,11 +198,18 @@ resource "google_container_node_pool" "jenkins_workers_c4_fallback" {
     enable_confidential_storage = false
     image_type                  = "COS_CONTAINERD"
     labels = {
-      "worktype" = "workers"
+      "worktype"                       = "workers"
+      "cloud.google.com/compute-class" = "jenkins-workers-x86"
     }
     local_ssd_count = 0
     logging_variant = "DEFAULT"
     machine_type    = "c4-standard-32"
+
+    taint {
+      key    = "cloud.google.com/compute-class"
+      value  = "jenkins-workers-x86"
+      effect = "NO_SCHEDULE"
+    }
     metadata = {
       "disable-legacy-endpoints" = "true"
     }
@@ -238,16 +252,17 @@ resource "google_container_node_pool" "jenkins_workers_c4_fallback" {
 }
 
 
-# arm64 fallback pool. Shares the "workload=workers" node label with
-# jenkins-workers-multiarch-c4a so arm agent pods can land here when C4A
-# capacity is unavailable. T2A runs in us-central1-a/b/f (not -c) and
-# supports pd-balanced boot disks only (no hyperdisk). GKE auto-taints arm
-# nodes with kubernetes.io/arch=arm64:NoSchedule.
-resource "google_container_node_pool" "jenkins_workers_t2a_fallback" {
+# arm64 fallback pool, priority 2 of the jenkins-workers-arm ComputeClass:
+# arm agent pods land here when C4A is out of capacity. N4A is Axion, like C4A,
+# and accepts hyperdisk-balanced -- which matters because a pod's volume spec is
+# fixed before scheduling, so both arm families have to accept the same /j volume.
+# This replaced a T2A pool that could take neither Hyperdisk nor Local SSD.
+# GKE auto-taints arm nodes with kubernetes.io/arch=arm64:NoSchedule.
+resource "google_container_node_pool" "jenkins_workers_n4a_fallback" {
   cluster            = google_container_cluster.jenkins_test.name
   location           = google_container_cluster.jenkins_test.location
   max_pods_per_node  = 110
-  name               = "jenkins-workers-t2a-fallback"
+  name               = "jenkins-workers-n4a-fallback"
   initial_node_count = 0
   autoscaling {
     total_min_node_count = 0
@@ -257,6 +272,7 @@ resource "google_container_node_pool" "jenkins_workers_t2a_fallback" {
   node_locations = [
     "us-central1-a",
     "us-central1-b",
+    "us-central1-c",
     "us-central1-f",
   ]
   project = "prompt-proto"
@@ -273,15 +289,22 @@ resource "google_container_node_pool" "jenkins_workers_t2a_fallback" {
 
   node_config {
     disk_size_gb                = 900
-    disk_type                   = "pd-balanced"
+    disk_type                   = "hyperdisk-balanced"
     enable_confidential_storage = false
     image_type                  = "COS_CONTAINERD"
     labels = {
-      "workload" = "workers"
+      "workload"                       = "workers"
+      "cloud.google.com/compute-class" = "jenkins-workers-arm"
     }
     local_ssd_count = 0
     logging_variant = "DEFAULT"
-    machine_type    = "t2a-standard-32"
+    machine_type    = "n4a-standard-32"
+
+    taint {
+      key    = "cloud.google.com/compute-class"
+      value  = "jenkins-workers-arm"
+      effect = "NO_SCHEDULE"
+    }
     metadata = {
       "disable-legacy-endpoints" = "true"
     }
@@ -359,11 +382,18 @@ resource "google_container_node_pool" "jenkins_workers_multiarch_c4a" {
     enable_confidential_storage = false
     image_type                  = "COS_CONTAINERD"
     labels = {
-      "workload" = "workers"
+      "workload"                       = "workers"
+      "cloud.google.com/compute-class" = "jenkins-workers-arm"
     }
     local_ssd_count = 0
     logging_variant = "DEFAULT"
     machine_type    = "c4a-standard-32"
+
+    taint {
+      key    = "cloud.google.com/compute-class"
+      value  = "jenkins-workers-arm"
+      effect = "NO_SCHEDULE"
+    }
     metadata = {
       "disable-legacy-endpoints" = "true"
     }

--- a/terraform/prod/nodepool.tf
+++ b/terraform/prod/nodepool.tf
@@ -77,8 +77,9 @@ resource "google_container_node_pool" "jenkins_workers_c4d" {
   name               = "jenkins-workers-c4d"
   initial_node_count = 4
   autoscaling {
-    min_node_count       = 0
+    total_min_node_count = 0
     total_max_node_count = 8
+    location_policy      = "ANY"
   }
   node_locations = [
     "us-central1-c",
@@ -143,6 +144,10 @@ resource "google_container_node_pool" "jenkins_workers_c4d" {
     max_unavailable = 0
     strategy        = "SURGE"
   }
+
+  lifecycle {
+    ignore_changes = [initial_node_count]
+  }
 }
 
 
@@ -154,8 +159,9 @@ resource "google_container_node_pool" "jenkins_workers_multiarch_c4a" {
   name               = "jenkins-workers-multiarch-c4a"
   initial_node_count = 9
   autoscaling {
-    min_node_count = 0
-    max_node_count = 8
+    total_min_node_count = 0
+    total_max_node_count = 8
+    location_policy      = "ANY"
   }
   node_locations = [
     "us-central1-c",
@@ -217,5 +223,9 @@ resource "google_container_node_pool" "jenkins_workers_multiarch_c4a" {
     max_surge       = 1
     max_unavailable = 0
     strategy        = "SURGE"
+  }
+
+  lifecycle {
+    ignore_changes = [initial_node_count]
   }
 }

--- a/terraform/prod/nodepool.tf
+++ b/terraform/prod/nodepool.tf
@@ -151,6 +151,171 @@ resource "google_container_node_pool" "jenkins_workers_c4d" {
 }
 
 
+# x86 fallback pool. Shares the "worktype=workers" node label with
+# jenkins-workers-c4d so x86 agent pods can land here when C4D capacity is
+# unavailable (stockout). c4-standard-32 is also hyperdisk-only.
+resource "google_container_node_pool" "jenkins_workers_c4_fallback" {
+  cluster            = google_container_cluster.jenkins_test.name
+  location           = google_container_cluster.jenkins_test.location
+  max_pods_per_node  = 110
+  name               = "jenkins-workers-c4-fallback"
+  initial_node_count = 0
+  autoscaling {
+    total_min_node_count = 0
+    total_max_node_count = 8
+    location_policy      = "ANY"
+  }
+  node_locations = [
+    "us-central1-c",
+    "us-central1-a",
+  ]
+  project = "prompt-proto"
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  network_config {
+    create_pod_range     = false
+    enable_private_nodes = true
+  }
+
+  node_config {
+    disk_size_gb                = 900
+    disk_type                   = "hyperdisk-balanced"
+    enable_confidential_storage = false
+    image_type                  = "COS_CONTAINERD"
+    labels = {
+      "worktype" = "workers"
+    }
+    local_ssd_count = 0
+    logging_variant = "DEFAULT"
+    machine_type    = "c4-standard-32"
+    metadata = {
+      "disable-legacy-endpoints" = "true"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append",
+    ]
+    preemptible = false
+    resource_labels = {
+      "worktype" = "workers"
+    }
+    resource_manager_tags = {}
+    service_account       = "default"
+    spot                  = false
+    tags                  = []
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = true
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+    strategy        = "SURGE"
+  }
+
+  lifecycle {
+    ignore_changes = [initial_node_count]
+  }
+}
+
+
+# arm64 fallback pool. Shares the "workload=workers" node label with
+# jenkins-workers-multiarch-c4a so arm agent pods can land here when C4A
+# capacity is unavailable. T2A is only offered in us-central1-a here and
+# supports pd-balanced boot disks only (no hyperdisk). GKE auto-taints arm
+# nodes with kubernetes.io/arch=arm64:NoSchedule.
+resource "google_container_node_pool" "jenkins_workers_t2a_fallback" {
+  cluster            = google_container_cluster.jenkins_test.name
+  location           = google_container_cluster.jenkins_test.location
+  max_pods_per_node  = 110
+  name               = "jenkins-workers-t2a-fallback"
+  initial_node_count = 0
+  autoscaling {
+    total_min_node_count = 0
+    total_max_node_count = 8
+    location_policy      = "ANY"
+  }
+  node_locations = [
+    "us-central1-a",
+  ]
+  project = "prompt-proto"
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  network_config {
+    create_pod_range     = false
+    enable_private_nodes = true
+  }
+
+  node_config {
+    disk_size_gb                = 900
+    disk_type                   = "pd-balanced"
+    enable_confidential_storage = false
+    image_type                  = "COS_CONTAINERD"
+    labels = {
+      "workload" = "workers"
+    }
+    local_ssd_count = 0
+    logging_variant = "DEFAULT"
+    machine_type    = "t2a-standard-32"
+    metadata = {
+      "disable-legacy-endpoints" = "true"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append",
+    ]
+    preemptible           = false
+    resource_labels       = {}
+    resource_manager_tags = {}
+    service_account       = "default"
+    spot                  = false
+    tags                  = []
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = true
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+    strategy        = "SURGE"
+  }
+
+  lifecycle {
+    ignore_changes = [initial_node_count]
+  }
+}
+
+
 # google_container_node_pool.jenkins_workers_multiarch_c4a:
 resource "google_container_node_pool" "jenkins_workers_multiarch_c4a" {
   cluster            = google_container_cluster.jenkins_test.name

--- a/terraform/prod/nodepool.tf
+++ b/terraform/prod/nodepool.tf
@@ -82,8 +82,10 @@ resource "google_container_node_pool" "jenkins_workers_c4d" {
     location_policy      = "ANY"
   }
   node_locations = [
-    "us-central1-c",
     "us-central1-a",
+    "us-central1-b",
+    "us-central1-c",
+    "us-central1-f",
   ]
   project = "prompt-proto"
 
@@ -166,8 +168,10 @@ resource "google_container_node_pool" "jenkins_workers_c4_fallback" {
     location_policy      = "ANY"
   }
   node_locations = [
-    "us-central1-c",
     "us-central1-a",
+    "us-central1-b",
+    "us-central1-c",
+    "us-central1-f",
   ]
   project = "prompt-proto"
 
@@ -236,7 +240,7 @@ resource "google_container_node_pool" "jenkins_workers_c4_fallback" {
 
 # arm64 fallback pool. Shares the "workload=workers" node label with
 # jenkins-workers-multiarch-c4a so arm agent pods can land here when C4A
-# capacity is unavailable. T2A is only offered in us-central1-a here and
+# capacity is unavailable. T2A runs in us-central1-a/b/f (not -c) and
 # supports pd-balanced boot disks only (no hyperdisk). GKE auto-taints arm
 # nodes with kubernetes.io/arch=arm64:NoSchedule.
 resource "google_container_node_pool" "jenkins_workers_t2a_fallback" {
@@ -252,6 +256,8 @@ resource "google_container_node_pool" "jenkins_workers_t2a_fallback" {
   }
   node_locations = [
     "us-central1-a",
+    "us-central1-b",
+    "us-central1-f",
   ]
   project = "prompt-proto"
 
@@ -329,8 +335,10 @@ resource "google_container_node_pool" "jenkins_workers_multiarch_c4a" {
     location_policy      = "ANY"
   }
   node_locations = [
-    "us-central1-c",
     "us-central1-a",
+    "us-central1-b",
+    "us-central1-c",
+    "us-central1-f",
   ]
   project = "prompt-proto"
 

--- a/terraform/prod/storage.tf
+++ b/terraform/prod/storage.tf
@@ -19,12 +19,12 @@ resource "google_compute_backend_bucket" "doxygen_dev_backend" {
   edge_security_policy    = null
   enable_cdn              = true
   cdn_policy {
-    cache_mode        = "CACHE_ALL_STATIC"
-    client_ttl        = 3600
-    default_ttl       = 3600
-    max_ttl           = 86400
-    negative_caching  = true
-    serve_while_stale = 86400
+    cache_mode         = "CACHE_ALL_STATIC"
+    client_ttl         = 3600
+    default_ttl        = 3600
+    max_ttl            = 86400
+    negative_caching   = true
+    serve_while_stale  = 86400
     request_coalescing = true
   }
 }
@@ -39,12 +39,12 @@ resource "google_compute_backend_bucket" "doxygen_backend" {
   edge_security_policy    = null
   enable_cdn              = true
   cdn_policy {
-    cache_mode        = "CACHE_ALL_STATIC"
-    client_ttl        = 3600
-    default_ttl       = 3600
-    max_ttl           = 86400
-    negative_caching  = true
-    serve_while_stale = 86400
+    cache_mode         = "CACHE_ALL_STATIC"
+    client_ttl         = 3600
+    default_ttl        = 3600
+    max_ttl            = 86400
+    negative_caching   = true
+    serve_while_stale  = 86400
     request_coalescing = true
   }
 }


### PR DESCRIPTION
Recently we have hit gke limits on workers that are set to c4d. This adds more location for c4d as well as allow for c4(x86) and n4a(arch64) to be a fallback. We are also adding monitoring to get a better idea of usage.